### PR TITLE
feat(deletePlace): implement delete place method

### DIFF
--- a/__tests__/groundplaces/deleteStopCluster.spec.ts
+++ b/__tests__/groundplaces/deleteStopCluster.spec.ts
@@ -88,7 +88,7 @@ describe('#deleteStopCluster', () => {
     ]);
   });
 
-  it('should throw an error if the StopCluster to delete is not empty', () => {
+  it('should throw an error if the StopCluster to delete has children', () => {
     let thrownError: Error;
 
     try {
@@ -98,7 +98,7 @@ describe('#deleteStopCluster', () => {
     }
 
     expect(thrownError).toEqual(
-      new Error('The cluster with the Gpuid c|FRstrasbou@u0ts2 cannot be deleted because it is not empty.'),
+      new Error('The "cluster" with the Gpuid "c|FRstrasbou@u0ts2" cannot be deleted because it has children.'),
     );
   });
 
@@ -112,7 +112,7 @@ describe('#deleteStopCluster', () => {
     }
 
     expect(thrownError).toEqual(
-      new Error('The cluster with the Gpuid c|FRstrasbou@u0ts22 cannot be deleted because it cannot be found.'),
+      new Error('The "cluster" with the Gpuid "c|FRstrasbou@u0ts22" cannot be deleted because it cannot be found.'),
     );
   });
 
@@ -126,7 +126,7 @@ describe('#deleteStopCluster', () => {
     }
 
     expect(thrownError).toEqual(
-      new Error('The cluster with the Gpuid g|FRststbi__@u0tkxd cannot be deleted because it cannot be found.'),
+      new Error('The "cluster" with the Gpuid "g|FRststbi__@u0tkxd" cannot be deleted because it cannot be found.'),
     );
   });
 });

--- a/__tests__/groundplaces/deleteStopCluster.spec.ts
+++ b/__tests__/groundplaces/deleteStopCluster.spec.ts
@@ -1,0 +1,132 @@
+import { GroundPlacesController } from '../../src/classes/groundplaces';
+import * as largeGroundPlacesFile from '../../mocks/largeGroundPlacesFile.json';
+import { GroundPlacesFile } from '../../src/types';
+
+describe('#deleteStopCluster', () => {
+  const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+  groundPlacesService.init(largeGroundPlacesFile as GroundPlacesFile);
+
+  it('should delete the StopCluster if its empty (no childs) and the Gpuid exist', () => {
+    groundPlacesService.deleteStopCluster('c|FRnaarto__@u0skg');
+
+    expect(groundPlacesService.getGroundPlaces()).toStrictEqual([
+      {
+        gpuid: 'c|FRstrasbou@u0ts2',
+        unique_name: 'strasbourg',
+        childs: ['g|FRststbi__@u0tkxd', 'g|FRstrasbou@u0tkru', 'g|FRstraroet@u0tkr3'],
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        is_latest: true,
+        name: 'Strasbourg, Grand-Est, France',
+        longitude: 7.74815,
+        latitude: 48.583,
+        type: 'cluster',
+      },
+      {
+        gpuid: 'g|FRststbi__@u0tkxd',
+        childs: [],
+        name: 'Strasbourg, Strasbourg - Bischheim',
+        longitude: 7.719863,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.616228,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'g|FRstrasbou@u0tkru',
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'flixbus',
+            name: 'Strasbourg',
+            latitude: 48.574179,
+            serviced: 'False',
+            company_id: 5,
+            longitude: 7.754266,
+            id: '23',
+          },
+        ],
+        name: 'Strasbourg',
+        longitude: 7.73417,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.58392,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'g|FRstraroet@u0tkr3',
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'vsc',
+            name: 'Strasbourg Roethig',
+            latitude: 48.569,
+            serviced: 'False',
+            company_id: 10,
+            longitude: 7.704,
+            id: 'FRBUK',
+          },
+        ],
+        name: 'Strasbourg Roethig',
+        longitude: 7.704,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.569,
+        is_latest: true,
+        type: 'group',
+      },
+    ]);
+  });
+
+  it('should throw an error if the StopCluster to delete is not empty', () => {
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.deleteStopCluster('c|FRstrasbou@u0ts2');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error('The cluster with the Gpuid c|FRstrasbou@u0ts2 cannot be deleted because it is not empty.'),
+    );
+  });
+
+  it('should throw an error if the StopCluster to delete is not found', () => {
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.deleteStopCluster('c|FRstrasbou@u0ts22');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error('The cluster with the Gpuid c|FRstrasbou@u0ts22 cannot be deleted because it cannot be found.'),
+    );
+  });
+
+  it('should throw an error if the StopCluster to delete is not a StopCluster', () => {
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.deleteStopCluster('g|FRststbi__@u0tkxd');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error('The cluster with the Gpuid g|FRststbi__@u0tkxd cannot be deleted because it cannot be found.'),
+    );
+  });
+});

--- a/__tests__/groundplaces/deleteStopGroup.spec.ts
+++ b/__tests__/groundplaces/deleteStopGroup.spec.ts
@@ -1,0 +1,133 @@
+import { GroundPlacesController } from '../../src/classes/groundplaces';
+import * as largeGroundPlacesFile from '../../mocks/largeGroundPlacesFile.json';
+import { GroundPlacesFile } from '../../src/types';
+
+describe('#deleteStopGroup', () => {
+  const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+  groundPlacesService.init(largeGroundPlacesFile as GroundPlacesFile);
+
+  it('should delete the StopGroup if its empty (no childs) and the Gpuid exist', () => {
+    groundPlacesService.deleteStopGroup('g|FRststbi__@u0tkxd');
+
+    expect(groundPlacesService.getGroundPlaces()).toStrictEqual([
+      {
+        gpuid: 'c|FRstrasbou@u0ts2',
+        unique_name: 'strasbourg',
+        childs: ['g|FRststbi__@u0tkxd', 'g|FRstrasbou@u0tkru', 'g|FRstraroet@u0tkr3'],
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        is_latest: true,
+        name: 'Strasbourg, Grand-Est, France',
+        longitude: 7.74815,
+        latitude: 48.583,
+        type: 'cluster',
+      },
+      {
+        gpuid: 'g|FRstrasbou@u0tkru',
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'flixbus',
+            name: 'Strasbourg',
+            latitude: 48.574179,
+            serviced: 'False',
+            company_id: 5,
+            longitude: 7.754266,
+            id: '23',
+          },
+        ],
+        name: 'Strasbourg',
+        longitude: 7.73417,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.58392,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'g|FRstraroet@u0tkr3',
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'vsc',
+            name: 'Strasbourg Roethig',
+            latitude: 48.569,
+            serviced: 'False',
+            company_id: 10,
+            longitude: 7.704,
+            id: 'FRBUK',
+          },
+        ],
+        name: 'Strasbourg Roethig',
+        longitude: 7.704,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.569,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'c|FRnaarto__@u0skg',
+        unique_name: 'nancy---tous-les-arrets',
+        childs: [],
+        serviced: 'True',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        is_latest: true,
+        name: 'Nancy - Tous les arrêts, Grand Est, France',
+        longitude: 6.1444727044,
+        latitude: 48.6484863111,
+        type: 'cluster',
+      },
+    ]);
+  });
+
+  it('should throw an error if the StopGroup to delete is not empty', () => {
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.deleteStopGroup('g|FRstrasbou@u0tkru');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error('The group with the Gpuid g|FRstrasbou@u0tkru cannot be deleted because it is not empty.'),
+    );
+  });
+
+  it('should throw an error if the StopGroup to delete is not found', () => {
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.deleteStopGroup('g|FRstrasbou@u0tkruu');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error('The group with the Gpuid g|FRstrasbou@u0tkruu cannot be deleted because it cannot be found.'),
+    );
+  });
+
+  it('should throw an error if the StopGroup to delete is not a StopGroup', () => {
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.deleteStopGroup('c|FRnaarto__@u0skg');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error('The group with the Gpuid c|FRnaarto__@u0skg cannot be deleted because it cannot be found.'),
+    );
+  });
+});

--- a/__tests__/groundplaces/deleteStopGroup.spec.ts
+++ b/__tests__/groundplaces/deleteStopGroup.spec.ts
@@ -6,14 +6,14 @@ describe('#deleteStopGroup', () => {
   const groundPlacesService: GroundPlacesController = new GroundPlacesController();
   groundPlacesService.init(largeGroundPlacesFile as GroundPlacesFile);
 
-  it('should delete the StopGroup if its empty (no childs) and the Gpuid exist', () => {
+  it('should delete the StopGroup if its empty (no childs) and the Gpuid exist and remove reference inside its StopCluster parent', () => {
     groundPlacesService.deleteStopGroup('g|FRststbi__@u0tkxd');
 
     expect(groundPlacesService.getGroundPlaces()).toStrictEqual([
       {
         gpuid: 'c|FRstrasbou@u0ts2',
         unique_name: 'strasbourg',
-        childs: ['g|FRststbi__@u0tkxd', 'g|FRstrasbou@u0tkru', 'g|FRstraroet@u0tkr3'],
+        childs: ['g|FRstrasbou@u0tkru', 'g|FRstraroet@u0tkr3'],
         serviced: 'False',
         has_been_modified: false,
         warning: false,
@@ -89,7 +89,7 @@ describe('#deleteStopGroup', () => {
     ]);
   });
 
-  it('should throw an error if the StopGroup to delete is not empty', () => {
+  it('should throw an error if the StopGroup to delete has children', () => {
     let thrownError: Error;
 
     try {
@@ -99,7 +99,7 @@ describe('#deleteStopGroup', () => {
     }
 
     expect(thrownError).toEqual(
-      new Error('The group with the Gpuid g|FRstrasbou@u0tkru cannot be deleted because it is not empty.'),
+      new Error('The "group" with the Gpuid "g|FRstrasbou@u0tkru" cannot be deleted because it has children.'),
     );
   });
 
@@ -113,7 +113,7 @@ describe('#deleteStopGroup', () => {
     }
 
     expect(thrownError).toEqual(
-      new Error('The group with the Gpuid g|FRstrasbou@u0tkruu cannot be deleted because it cannot be found.'),
+      new Error('The "group" with the Gpuid "g|FRstrasbou@u0tkruu" cannot be deleted because it cannot be found.'),
     );
   });
 
@@ -127,7 +127,7 @@ describe('#deleteStopGroup', () => {
     }
 
     expect(thrownError).toEqual(
-      new Error('The group with the Gpuid c|FRnaarto__@u0skg cannot be deleted because it cannot be found.'),
+      new Error('The "group" with the Gpuid "c|FRnaarto__@u0skg" cannot be deleted because it cannot be found.'),
     );
   });
 });

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -58,7 +58,6 @@ export class GroundPlacesController {
    * If you do not give filters, the list will not be filtered.
    * @returns {GroundPlace[]}
    */
-  // @ts-ignore
   public autocomplete(query: string, filters?: AutocompleteFilter[]): GroundPlace[] {
     const groundPlaces: GroundPlace[] = this.getGroundPlaces();
 
@@ -216,14 +215,6 @@ export class GroundPlacesController {
   ): void {}
 
   /**
-   * @description Delete place only if it's empty.
-   * @param {GroundPlaceType} groundPlaceType - Ground place type 'cluster' or 'group'.
-   * @param {StopGroupGpuid|StopClusterGpuid} placeToRemoveGpuid - Ground place unique identifier of the place to remove.
-   * @returns {void}
-   */
-  public deletePlace(groundPlaceType: GroundPlaceType, placeToRemoveGpuid: StopGroupGpuid | StopClusterGpuid): void {}
-
-  /**
    * @description Add a stopGroup to a stopCluster.
    * @param {StopGroupGpuid} stopGroupToAddGpuid - Ground place unique identifier of the stopGroup to add.
    * @param {StopClusterGpuid} intoStopClusterGpuid - Ground Place unique identifier of the stopCluster.
@@ -256,14 +247,18 @@ export class GroundPlacesController {
    * @param {StopGroupGpuid} stopGroupGpuid - Ground place unique identifier of the StopGroup to remove.
    * @returns {void}
    */
-  public deleteStopGroup(stopGroupGpuid: StopGroupGpuid): void {}
+  public deleteStopGroup(stopGroupGpuid: StopGroupGpuid): void {
+    this.storageService.deletePlace(stopGroupGpuid, GroundPlaceType.GROUP);
+  }
 
   /**
    * @description Delete StopCluster only if empty.
    * @param {StopClusterGpuid} stopClusterGpuid - Ground place unique identifier of the StopCluster to remove.
    * @returns {void}
    */
-  public deleteStopCluster(stopClusterGpuid: StopClusterGpuid): void {}
+  public deleteStopCluster(stopClusterGpuid: StopClusterGpuid): void {
+    this.storageService.deletePlace(stopClusterGpuid, GroundPlaceType.CLUSTER);
+  }
 
   /**
    * @description Getter to retrieve the Ground places.

--- a/src/classes/storage.ts
+++ b/src/classes/storage.ts
@@ -100,4 +100,30 @@ export class Storage {
 
     this.groundPlaces[placeIndex] = newGroundPlace;
   }
+
+  /**
+   * @description Delete place only if it's empty.
+   * @param {Gpuid} placeToRemoveGpuid - Ground place unique identifier of the place to remove.
+   * @param {GroundPlaceType} placeType - The type of the place to remove, can be StopGroup or StopCluster.
+   * @returns {void}
+   */
+  public deletePlace(placeToRemoveGpuid: Gpuid, placeType: GroundPlaceType): void {
+    const placeIndex: number = this.groundPlaces.findIndex(({ gpuid }: GroundPlace) => gpuid === placeToRemoveGpuid);
+
+    const groundPlace: GroundPlace | undefined = this.groundPlaces[placeIndex];
+
+    if (!groundPlace || groundPlace.type !== placeType) {
+      throw new Error(
+        `The ${placeType} with the Gpuid ${placeToRemoveGpuid} cannot be deleted because it cannot be found.`,
+      );
+    }
+
+    if (groundPlace.childs.length) {
+      throw new Error(
+        `The ${placeType} with the Gpuid ${placeToRemoveGpuid} cannot be deleted because it is not empty.`,
+      );
+    }
+
+    this.groundPlaces.splice(placeIndex, 1);
+  }
 }

--- a/src/classes/storage.ts
+++ b/src/classes/storage.ts
@@ -129,20 +129,19 @@ export class Storage {
 
     // If the place is a StopGroup, all references to this StopGroup are also removed from its possible StopCluster parent.
     if (placeType === GroundPlaceType.GROUP) {
-      this.groundPlaces.reduce((reduceGroundPlaces: GroundPlace[], groundPlace: GroundPlace): GroundPlace[] => {
-        // Search through children from StopCluster that have a reference to the StopGroup deleted.
-        if (groundPlace.type === GroundPlaceType.CLUSTER && groundPlace.childs.includes(placeToRemoveGpuid)) {
-          const referenceIndex: number = groundPlace.childs.findIndex(
-            (stopGroupGpuid: StopGroupGpuid) => stopGroupGpuid === placeToRemoveGpuid,
-          );
+      this.groundPlaces.map(
+        (groundPlace: GroundPlace): GroundPlace => {
+          if (groundPlace.type === GroundPlaceType.CLUSTER && groundPlace.childs.includes(placeToRemoveGpuid)) {
+            const referenceIndex: number = groundPlace.childs.findIndex(
+              (stopGroupGpuid: StopGroupGpuid) => stopGroupGpuid === placeToRemoveGpuid,
+            );
 
-          groundPlace.childs.splice(referenceIndex, 1);
-        }
+            groundPlace.childs.splice(referenceIndex, 1);
+          }
 
-        reduceGroundPlaces.push(groundPlace);
-
-        return reduceGroundPlaces;
-      }, []);
+          return groundPlace;
+        },
+      );
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "lib": ["ES2019"],
-    "target": "ES2019",
+    "lib": ["ES2018"],
+    "target": "ES2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "alwaysStrict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "lib": ["ES2018"],
-    "target": "ES2018",
+    "lib": ["ES2019"],
+    "target": "ES2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "alwaysStrict": true,


### PR DESCRIPTION
This PR aim to implement the `deletePlace` method for **Storage** class. 

This method is used by `deleteStopGroup` and `deleteStopCluster` methods from **GroundPlaceController**. 
That these two methods that'll be use by the user of the package.
